### PR TITLE
No longer use user-data

### DIFF
--- a/templates/runner-configs/linux-arm64.yaml
+++ b/templates/runner-configs/linux-arm64.yaml
@@ -16,6 +16,7 @@ runner_config:
       - github-runner-ubuntu-jammy-arm64-*
     state:
       - available
+  enable_userdata: false
   ami_owners:
     - "052730242331"
   instance_types:
@@ -31,14 +32,13 @@ runner_config:
       throughput: null
       kms_key_id: null
       snapshot_id: null
-  userdata_template: ./templates/user-data.sh
   runners_maximum_count: 16
   enable_ephemeral_runners: false
   instance_allocation_strategy: price-capacity-optimized
   create_service_linked_role_spot: true
   scale_down_schedule_expression: cron(* * * * ? *)
   runner_metadata_options:
-    instance_metadata_tags: disabled
+    instance_metadata_tags: enabled
     http_endpoint: enabled
     http_tokens: optional
     http_put_response_hop_limit: 1

--- a/templates/runner-configs/linux-x64.yaml
+++ b/templates/runner-configs/linux-x64.yaml
@@ -16,6 +16,7 @@ runner_config:
       - github-runner-ubuntu-jammy-amd64-*
     state:
       - available
+  enable_userdata: false
   ami_owners:
     - "052730242331"
   instance_types:
@@ -41,14 +42,13 @@ runner_config:
       throughput: null
       kms_key_id: null
       snapshot_id: null
-  userdata_template: ./templates/user-data.sh
   runners_maximum_count: 16
   enable_ephemeral_runners: false
   instance_allocation_strategy: price-capacity-optimized
   create_service_linked_role_spot: true
   scale_down_schedule_expression: cron(* * * * ? *)
   runner_metadata_options:
-    instance_metadata_tags: disabled
+    instance_metadata_tags: enabled
     http_endpoint: enabled
     http_tokens: optional
     http_put_response_hop_limit: 1


### PR DESCRIPTION
Prevents the reinstallation of the GH agent on each startup. Seems we need metadata, though the docs are unclear quite why.

Still investigating why it's not picking up new work though.