### PR TITLE
Switch x64 runners to on-demand with updated instance types

### DIFF
--- a/templates/runner-configs/linux-x64-builder.yaml
+++ b/templates/runner-configs/linux-x64-builder.yaml
@@ -20,18 +20,23 @@ runner_config:
   ami_owners:
     - "052730242331"
   instance_types:
-    - c5.8xlarge
-    - c5a.8xlarge
-    - c6i.8xlarge
-    - c6a.8xlarge
-    - c5.12xlarge
-    - c5.16xlarge
-    - c5a.16xlarge
-    - c6i.16xlarge
-    - c6a.16xlarge
-    - c5a.24xlarge
-    - c6i.24xlarge
-    - c6a.24xlarge
+    # 32 vCPUs
+    - c6a.8xlarge       # AMD EPYC
+    - c5a.8xlarge       # AMD EPYC
+    - c7i-flex.8xlarge  # Intel Sapphire Rapids
+    - c6i.8xlarge       # Intel Ice Lake
+    # 48 vCPUs
+    - c6a.12xlarge      # AMD EPYC
+    - c5a.12xlarge      # AMD EPYC
+    - c7i-flex.12xlarge # Intel Sapphire Rapids
+    - c5.12xlarge       # Intel Skylake/Cascade Lake
+    - c6i.12xlarge      # Intel Ice Lake
+    # 64 vCPUs
+    - c6a.16xlarge      # AMD EPYC
+    - c5a.16xlarge      # AMD EPYC
+    - c7i-flex.16xlarge # Intel Sapphire Rapids
+    - c6i.16xlarge      # Intel Ice Lake
+  instance_target_capacity_type: on-demand
   block_device_mappings:
     - device_name: /dev/sda1
       delete_on_termination: true

--- a/templates/runner-configs/linux-x64.yaml
+++ b/templates/runner-configs/linux-x64.yaml
@@ -20,18 +20,23 @@ runner_config:
   ami_owners:
     - "052730242331"
   instance_types:
-    - c5.8xlarge
-    - c5a.8xlarge
-    - c6i.8xlarge
-    - c6a.8xlarge
-    - c5.12xlarge
-    - c5.16xlarge
-    - c5a.16xlarge
-    - c6i.16xlarge
-    - c6a.16xlarge
-    - c5a.24xlarge
-    - c6i.24xlarge
-    - c6a.24xlarge
+    # 32 vCPUs
+    - c6a.8xlarge       # AMD EPYC
+    - c5a.8xlarge       # AMD EPYC
+    - c7i-flex.8xlarge  # Intel Sapphire Rapids
+    - c6i.8xlarge       # Intel Ice Lake
+    # 48 vCPUs
+    - c6a.12xlarge      # AMD EPYC
+    - c5a.12xlarge      # AMD EPYC
+    - c7i-flex.12xlarge # Intel Sapphire Rapids
+    - c5.12xlarge       # Intel Skylake/Cascade Lake
+    - c6i.12xlarge      # Intel Ice Lake
+    # 64 vCPUs
+    - c6a.16xlarge      # AMD EPYC
+    - c5a.16xlarge      # AMD EPYC
+    - c7i-flex.16xlarge # Intel Sapphire Rapids
+    - c6i.16xlarge      # Intel Ice Lake
+  instance_target_capacity_type: on-demand
   block_device_mappings:
     - device_name: /dev/sda1
       delete_on_termination: true


### PR DESCRIPTION
## Summary
- Remove invalid instance types (c5.8xlarge, c5.16xlarge don't exist in AWS)
- Remove 24xlarge instances to keep costs under $3/hr on-demand
- Add c7i-flex instances (Intel Sapphire Rapids) for better price/performance
- Set `instance_target_capacity_type` to `on-demand`
- Add comments documenting vCPU counts and CPU types

## Instance types (all under $3/hr on-demand)
| vCPUs | Instance Types |
|-------|----------------|
| 32 | c6a.8xlarge, c5a.8xlarge, c7i-flex.8xlarge, c6i.8xlarge |
| 48 | c6a.12xlarge, c5a.12xlarge, c7i-flex.12xlarge, c5.12xlarge, c6i.12xlarge |
| 64 | c6a.16xlarge, c5a.16xlarge, c7i-flex.16xlarge, c6i.16xlarge |

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)