### PR TITLE
Add small (8 vCPU) and medium (16 vCPU) Linux runner tiers

### DIFF
--- a/templates/runner-configs/linux-x64-medium.yaml
+++ b/templates/runner-configs/linux-x64-medium.yaml
@@ -1,0 +1,62 @@
+matcherConfig:
+  exactMatch: true
+  labelMatchers:
+    - [self-hosted, ce, linux, x64, medium]
+fifo: true
+delay_webhook_event: 0
+runner_config:
+  runner_os: linux
+  runner_architecture: x64
+  runner_extra_labels: [ce]
+  runner_name_prefix: ce-x64-medium_
+  enable_ssm_on_runners: true
+  runner_run_as: "ubuntu"
+  ami:
+    filter:
+      name:
+        - github-runner-ubuntu-jammy-amd64-*
+      state:
+        - available
+    owners:
+      - "052730242331"
+  enable_userdata: false
+  instance_types:
+    # 16 vCPUs
+    - c6a.4xlarge       # AMD EPYC
+    - c5a.4xlarge       # AMD EPYC
+    - c7i-flex.4xlarge  # Intel Sapphire Rapids
+    - c6i.4xlarge       # Intel Ice Lake
+  instance_target_capacity_type: on-demand
+  block_device_mappings:
+    - device_name: /dev/sda1
+      delete_on_termination: true
+      volume_type: gp3
+      volume_size: 128
+      encrypted: true
+      iops: null
+      throughput: null
+      kms_key_id: null
+      snapshot_id: null
+  runners_maximum_count: 16
+  enable_ephemeral_runners: false
+  instance_allocation_strategy: price-capacity-optimized
+  create_service_linked_role_spot: true
+  scale_down_schedule_expression: cron(* * * * ? *)
+  runner_metadata_options:
+    instance_metadata_tags: enabled
+    http_endpoint: enabled
+    http_tokens: optional
+    http_put_response_hop_limit: 1
+  runner_log_files:
+    - log_group_name: syslog
+      prefix_log_group: true
+      file_path: /var/log/syslog
+      log_stream_name: "{instance_id}"
+    - log_group_name: user_data
+      prefix_log_group: true
+      file_path: /var/log/user-data.log
+      log_stream_name: "{instance_id}/user_data"
+    - log_group_name: runner
+      prefix_log_group: true
+      file_path: /opt/actions-runner/_diag/Runner_**.log
+      log_stream_name: "{instance_id}/runner"

--- a/templates/runner-configs/linux-x64-small.yaml
+++ b/templates/runner-configs/linux-x64-small.yaml
@@ -1,0 +1,62 @@
+matcherConfig:
+  exactMatch: true
+  labelMatchers:
+    - [self-hosted, ce, linux, x64, small]
+fifo: true
+delay_webhook_event: 0
+runner_config:
+  runner_os: linux
+  runner_architecture: x64
+  runner_extra_labels: [ce]
+  runner_name_prefix: ce-x64-small_
+  enable_ssm_on_runners: true
+  runner_run_as: "ubuntu"
+  ami:
+    filter:
+      name:
+        - github-runner-ubuntu-jammy-amd64-*
+      state:
+        - available
+    owners:
+      - "052730242331"
+  enable_userdata: false
+  instance_types:
+    # 8 vCPUs
+    - c6a.2xlarge       # AMD EPYC
+    - c5a.2xlarge       # AMD EPYC
+    - c7i-flex.2xlarge  # Intel Sapphire Rapids
+    - c6i.2xlarge       # Intel Ice Lake
+  instance_target_capacity_type: on-demand
+  block_device_mappings:
+    - device_name: /dev/sda1
+      delete_on_termination: true
+      volume_type: gp3
+      volume_size: 128
+      encrypted: true
+      iops: null
+      throughput: null
+      kms_key_id: null
+      snapshot_id: null
+  runners_maximum_count: 16
+  enable_ephemeral_runners: false
+  instance_allocation_strategy: price-capacity-optimized
+  create_service_linked_role_spot: true
+  scale_down_schedule_expression: cron(* * * * ? *)
+  runner_metadata_options:
+    instance_metadata_tags: enabled
+    http_endpoint: enabled
+    http_tokens: optional
+    http_put_response_hop_limit: 1
+  runner_log_files:
+    - log_group_name: syslog
+      prefix_log_group: true
+      file_path: /var/log/syslog
+      log_stream_name: "{instance_id}"
+    - log_group_name: user_data
+      prefix_log_group: true
+      file_path: /var/log/user-data.log
+      log_stream_name: "{instance_id}/user_data"
+    - log_group_name: runner
+      prefix_log_group: true
+      file_path: /opt/actions-runner/_diag/Runner_**.log
+      log_stream_name: "{instance_id}/runner"


### PR DESCRIPTION
## Summary
- Adds `linux-x64-small.yaml` runner config with 8 vCPU instances (c6a/c5a/c7i-flex/c6i `.2xlarge`) and `small` label
- Adds `linux-x64-medium.yaml` runner config with 16 vCPU instances (`.4xlarge`) and `medium` label
- Both share the same AMI, storage, logging, and scaling config as the existing `linux-x64` runners

## Notes
- **Terraform apply required** to deploy the new Lambda configs after merge
- Companion PR in compiler-workflows will route light builds to these new tiers

## Test plan
- [x] Review YAML configs match existing linux-x64.yaml structure
- [x] `terraform plan` shows expected new runner resources
- [ ] After apply, verify runners register with correct labels in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)