### PR TITLE
Install libfl-dev on builder so legacy toolchains' ar works

### DIFF
--- a/packer/install-builder-runner.sh
+++ b/packer/install-builder-runner.sh
@@ -82,6 +82,7 @@ apt update -y -q && apt upgrade -y -q && apt upgrade -y -q && apt install -y -q 
     curl \
     file \
     flex \
+    libfl-dev \
     gawk \
     git \
     libc6-dev-i386 \


### PR DESCRIPTION
## Problem

Library builds using **gcc-10.1.0** fail during archive creation:

```
/opt/compiler-explorer/gcc-10.1.0/bin/ar: error while loading shared libraries:
libfl.so.2: cannot open shared object file
```

(Example: fmt/trunk under g101/x86_64/libstdc++. gcc-10.2.0 builds fine.)

## Cause

gcc-10.1.0's bundled binutils `ar` is dynamically linked against `libfl.so.2` -- binutils picks up `-lfl` when flex's runtime library is present in the environment where it was built. The builder installs `flex`, but on Ubuntu the `flex` package only provides the flex *binary*; the runtime shared library `libfl.so.2` ships in `libfl2` (pulled in by `libfl-dev`), which is **not** a dependency of `flex`. So `ar` from that toolchain can't start.

gcc-10.2.0's `ar` wasn't linked against libfl, which is why it's unaffected.

## Fix

Add `libfl-dev` to the runner package list so `libfl.so.2` is present. Takes effect once the builder AMI is rebuilt; running runners can be unblocked immediately with `sudo apt-get install -y libfl2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)